### PR TITLE
use netcat to wait for cassandra in tilerator

### DIFF
--- a/tilerator/Dockerfile
+++ b/tilerator/Dockerfile
@@ -13,6 +13,7 @@ RUN apt update && \
              libgeos++-dev \
              osmctools \
              nmap \
+             netcat \
              postgis \
              redis-tools \
     && curl -sL https://deb.nodesource.com/setup_6.x | bash - \

--- a/tilerator/runserver.sh
+++ b/tilerator/runserver.sh
@@ -2,7 +2,22 @@
 set -e
 
 # wait for cassandra to be up
-/usr/local/bin/cassandra.wait
+CASSANDRA_SERVER=cassandra
+CASSANDRA_PORT=9042
+
+function wait_for_cassandra() {
+    for i in `seq 1 100`; do
+        nc -vz $CASSANDRA_SERVER $CASSANDRA_PORT
+        if [[ "$?" == "0" ]]; then
+            return 0
+        fi
+        sleep 1
+    done
+    # cassandra unreachable, exiting
+    exit 1
+}
+
+wait_for_cassandra
 
 # wait for the database to be loaded
 while true; do


### PR DESCRIPTION
hardcode the cassandra wait in tilerator.

I'll cleanup Qwant's tilerator fork to remove the useless scripts afterward